### PR TITLE
Scroll text enters from right

### DIFF
--- a/examples/ScrollText/ScrollText.ino
+++ b/examples/ScrollText/ScrollText.ino
@@ -35,7 +35,7 @@ void setup() {
 
 void loop() {
   MATRIX.beginText(0, 0); // use the same color as before
-  MATRIX.print("millis=");
+  MATRIX.print("   millis=");
   MATRIX.println(millis());
   MATRIX.endText(SCROLL_LEFT); // SCROLL_LEFT parameter here to configure scrolling left
 


### PR DESCRIPTION
Scroll text should enter smoothly from the right otherwise you miss it. Padded print string with a couple of leading spaces.