### PR TITLE
Update MKR RGB lib to enable use on the Portenta H7.  (A3->A5)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,9 +6,11 @@ Allows you to draw on your MKR RGB shield. Depends on the ArduinoGraphics librar
 
 For more information about this library please visit us at https://www.arduino.cc/en/Reference/ArduinoMKRRGB
 
+Updated:  Works with Portenta H7 - one jumper needed - A3 to A5.  A4 can be used as-is (after pinMode change).
+#define USING_PORTENTA_H7 - make sure this is uncommented in MKRRGBMatrix.h to use the MKR RGB shield in 'bit-bang' mode.
 == License ==
 
-Copyright (c) 2019 Arduino SA. All rights reserved.
+Copyright (c) 2020 Arduino SA. All rights reserved.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/src/MKRRGBMatrix.h
+++ b/src/MKRRGBMatrix.h
@@ -26,8 +26,8 @@
 #define RGB_MATRIX_HEIGHT 7
 
 // the following is for bit-bang of A4 and A3 jumpered to A5
-// uncomment if not using the Portenta H7
-#define USING_PORTENTA_H7
+// comment if not using the Portenta H7
+// #define USING_PORTENTA_H7
 
 class RGBMatrixClass : public ArduinoGraphics {
 public:

--- a/src/MKRRGBMatrix.h
+++ b/src/MKRRGBMatrix.h
@@ -1,6 +1,6 @@
 /*
   This file is part of the Arduino_MKRRGB library.
-  Copyright (c) 2019 Arduino SA. All rights reserved.
+  Copyright (c) 2020 Arduino SA. All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,10 @@
 
 #define RGB_MATRIX_WIDTH  12
 #define RGB_MATRIX_HEIGHT 7
+
+// the following is for bit-bang of A4 and A3 jumpered to A5
+// uncomment if not using the Portenta H7
+#define USING_PORTENTA_H7
 
 class RGBMatrixClass : public ArduinoGraphics {
 public:


### PR DESCRIPTION
Requires jumper from A3 to A5. 

First discussed [here:](https://github.com/arduino/ArduinoCore-mbed/issues/16).

