### PR TITLE
Fix broken compilation due to name change of SPIClass within ArduinoCore-samd.

### DIFF
--- a/src/MKRRGBMatrix.cpp
+++ b/src/MKRRGBMatrix.cpp
@@ -22,7 +22,7 @@
 
 #include "MKRRGBMatrix.h"
 
-static SPIClass SPI_MATRIX(&sercom0, A3, A4, A3, SPI_PAD_0_SCK_1, SERCOM_RX_PAD_0);
+static SPIClassSAMD SPI_MATRIX(&sercom0, A3, A4, A3, SPI_PAD_0_SCK_1, SERCOM_RX_PAD_0);
 
 // This table is based on the formula: gamma = (int)(pow(i / 255.0, gamma) * 255 + offset)
 // where gamma = 2.5 and offset is 0.5


### PR DESCRIPTION
See https://github.com/arduino/ArduinoCore-samd/commit/000db0c4b8007c71ebe4f45aa09ad996c4feb0af.

This fixes #16.