### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -36,30 +36,39 @@ jobs:
           - fqbn: arduino:samd:mkrzero
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrzero
           - fqbn: arduino:samd:mkr1000
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkr1000
           - fqbn: arduino:samd:mkrwifi1010
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrwifi1010
           - fqbn: arduino:samd:mkrfox1200
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrfox1200
           - fqbn: arduino:samd:mkrwan1300
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrwan1300
           - fqbn: arduino:samd:mkrwan1310
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrwan1310
           - fqbn: arduino:samd:mkrgsm1400
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrgsm1400
           - fqbn: arduino:samd:mkrnb1500
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrnb1500
           - fqbn: arduino:samd:mkrvidor4000
             platforms: |
               - name: arduino:samd
+            artifact-name-suffix: arduino-samd-mkrvidor4000
 
     steps:
       - name: Checkout repository
@@ -86,4 +95,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .